### PR TITLE
Lots of small fixes

### DIFF
--- a/sass/_buttons.scss
+++ b/sass/_buttons.scss
@@ -248,7 +248,7 @@ a.button {
 
     &.hide-text {
         padding-left: 0;
-        font-size: 0;
+        text-indent: -1000em;
         width: $size;
         margin-right: 1ex;
 

--- a/sass/_buttons.scss
+++ b/sass/_buttons.scss
@@ -294,3 +294,30 @@ a.button {
         }
     }
 }
+
+// Intercom launcher
+// 
+// markup:
+// <a class="contact-launcher">
+//     <i class="fa fa-question" aria-hidden="true"></i>
+// </a>
+//
+// Styleguide 4.6
+.contact-launcher {
+    $size: 46px;
+    $border: 2px;
+    display: block;
+    width: $size;
+    height: $size;
+    border-radius: 50%;
+    background: $color-bright-gray;
+    border: 2px solid white;
+    cursor: pointer;
+    box-shadow: 0 1px 6px rgba(0,0,0,.06),0 2px 32px rgba(0,0,0,.16);
+    text-align: center;
+    i {
+        line-height: $size - ($border * 2);
+        color: white;
+        font-size: $size / 2;
+    }
+}

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -168,6 +168,7 @@
     input {
         background: rgba(white,0.1);
         border: 0;
+        color: white;
         padding: 9px;
         display: block;
         flex-grow: 1;

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -192,7 +192,7 @@
 // Styleguide 5.6
 .spinner {
     border: 1px solid grey;
-    border-top-color: transparent;
+    border-top-color: transparent !important;
     border-radius: 50%;
     position: relative;
     animation: spinner-rotate 1s linear infinite;

--- a/sass/_dashboard.scss
+++ b/sass/_dashboard.scss
@@ -262,7 +262,6 @@
             display: block;
             width: 0;
             height: 0;
-            margin: 0 auto;
         }
     }
 

--- a/sass/_dashboard.scss
+++ b/sass/_dashboard.scss
@@ -166,10 +166,33 @@
         font-size: $size-5;
         font-weight: 800;
         margin: 0;
-        -webkit-line-clamp: 3;
-        -webkit-box-orient: vertical;
+        position: relative;
+        max-height: 3em; 
         overflow: hidden;
-        display: -webkit-box;
+
+        &:after {
+            content: "";
+            text-align: right;
+            position: absolute;
+            bottom: 0;
+            right: 0;
+            width: 50%;
+            height: 1.2em;
+            background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 80%);
+        }
+    }
+    @supports (-webkit-line-clamp: 3) {
+        h1 {
+            -webkit-line-clamp: 3;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            display: -webkit-box;
+            max-height: none;
+            
+            &:after {
+                display: none;
+            }
+        }
     }
     .subheading {
         overflow: hidden;
@@ -197,13 +220,13 @@
         color: #fff;
         font-size: $size-7;
         margin: $padding;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-        display: -webkit-box;
         opacity: 0;
         transition: opacity $transition-out-speed;
         transition-delay: $transition-out-delay;
+        position: relative;
+        max-height: 3em; 
+        overflow: hidden;
+
         cite {
             display: block;
             border-top: 1px solid rgba(255, 255, 255, 0.5);
@@ -211,6 +234,14 @@
             text-transform: uppercase;
             margin-top: 5px;
             padding-top: 5px;
+        }
+    
+        @supports (-webkit-line-clamp: 2) {
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            display: -webkit-box;
+            max-height: none;
         }
     }
 

--- a/sass/_dashboard.scss
+++ b/sass/_dashboard.scss
@@ -151,6 +151,7 @@
         padding-top: 3px;
         padding-right: 6px;
         width: calc(70% - #{$padding});
+        overflow: hidden;
     }
 
     .progress {

--- a/sass/_dashboard.scss
+++ b/sass/_dashboard.scss
@@ -498,6 +498,7 @@
         margin-bottom: 0;
 
         article {
+            background: grey;
             transform: rotate($rotation);
             overflow: hidden;
             position: relative;

--- a/sass/_layout.scss
+++ b/sass/_layout.scss
@@ -213,6 +213,10 @@ h6 {
     }
     .column {
         padding-bottom: 0;
+        flex-basis: auto;
+    }
+    .search {
+        flex-basis: auto;
     }
     .product-navigation {
         display: none;
@@ -364,6 +368,7 @@ h6 {
     }
     .page-navigation-container {
         display: none;
+        height: 100%;
         
         &.show {
             display: flex;
@@ -377,6 +382,11 @@ h6 {
     }
     .page-navigation {
         white-space: nowrap;
+    }
+    .desktop-navigation .page-navigation {
+        display: flex;
+        align-items: flex-end;
+        height: 100%;
     }
 }
 

--- a/sass/_layout.scss
+++ b/sass/_layout.scss
@@ -299,7 +299,7 @@ h6 {
 
         &.active {
             border-bottom-color: cyan;
-            a {
+            > a {
                 color: cyan;
             }
         }


### PR DESCRIPTION
- Add fallback background colour for the tri-hero component
- Make the spinner component easier to override by making the transparent portion of the border an `!important` style. Now to override you can just set the whole border color `border-color: red;` rather than `border-color: transparent red red red`
- Make the search form input box color white so you can see the text
- Make sure that the title in the content tile component has its overflow hidden from view
- Make sure that the active link colour in the hamburger menu is only applied to the immediate child anchor. Otherwise all the links in a sub menu will show as active
_ Fix a bunch of IE11 bugs in navigation and content tile, including implementing a line-clamp fallback and fixing reflow issues when the navigation is updated