### PR TITLE
RV-2110

### DIFF
--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -73,6 +73,9 @@
 //
 // A large (optional) clickable hero image.
 //
+// default  - Default
+// .deferredLoading - Lazy loaded image, container assumes 16:9 image size
+// 
 // markup:
 // <div class="hero-image">
 //     <a>
@@ -82,9 +85,23 @@
 //
 // Styleguide 5.2
 .hero-image {
+    position: relative;
+
     img {
         display: block;
         width:100%;
+    }
+
+    &.deferredLoading {
+        background: $color-bright-gray;
+        padding-top: 56.25%;
+        position: relative;
+
+        img {
+            position: absolute;
+            top: 0;
+            left: 0;
+        }
     }
 }
 


### PR DESCRIPTION
Adds deferredLoading modifier to hero-image component so that lazy loaded images dont "pop" into the page and change the layout.