### PR TITLE
Add img to logo styles

### DIFF
--- a/sass/_navigation.scss
+++ b/sass/_navigation.scss
@@ -542,13 +542,15 @@
         height: 10px;
         margin-left: 0;
     }
-    .logo svg {
-        display: block;
-        height: 42px;
-        width: 110px;
-        margin: ($baseline / 2) 0;
-        @include desktop {
-            margin: ($baseline / 2) 2.25rem ($baseline / 2) 0;
+    .logo {
+        svg, img {
+            display: block;
+            height: 42px;
+            width: 110px;
+            margin: ($baseline / 2) 0;
+            @include desktop {
+                margin: ($baseline / 2) 2.25rem ($baseline / 2) 0;
+            }
         }
     }
     .logo svg.logo_tv_small,


### PR DESCRIPTION
Fixes style bug if an image is used as a logo instead of an svg