### PR TITLE
RV-2454 - WP: Pre-paywall improvements - Product Links Block

### DIFF
--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -1626,27 +1626,27 @@
 //
 // markup:
 // <div class="product-links-block prospect-component">
-//    <div class="product-links--content">
-//        <div class="product-link product-link--tv {$modifiers}">
-//            <a href="#">
-//                <div class="columns is-vertically-centered">
-//                  <div class="column is-8-desktop is-12">
+//    <div class="product-link product-link--tv {$modifiers}">
+//        <a href="#">
+//            <div class="columns is-vertically-centered">
+//              <div class="column is-12">
+//                  <div class="product-link--content">
 //                      <div class="product-link--copy">
-//                       <h3>Real Vision <span class="is-highlighted">Television</span></h3>
-//                       <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
-//                       <ul>
+//                      <h3>Real Vision <span class="is-highlighted">Television</span></h3>
+//                      <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
+//                      <ul>
 //                          <li>Actionable insights from the world's smartest investors</li>
 //                          <li>Subscribe for just $597 / year at the end of your trial</li>
-//                       </ul>
+//                      </ul>
 //                      </div>
 //                  </div>
-//                  <div class="product-link__overlay">
-//                      <span class="button" href="/">Check It Out!</span>
-//                      <p class="product-link__arrow"></p>
-//                  </div>
-//                </div>
-//            </a>
-//        </div>
+//              </div>
+//              <div class="product-link__overlay">
+//                  <span class="button" href="/">Check It Out!</span>
+//                  <p class="product-link__arrow"></p>
+//              </div>
+//            </div>
+//        </a>
 //    </div>
 // </div>
 // <div class="product-links-block prospect-component">
@@ -1654,14 +1654,16 @@
 //        <div class="product-link product-link--think-tank {$modifiers}">
 //            <a href="#">
 //                <div class="columns is-vertically-centered">
-//                  <div class="column is-8-desktop is-12">
-//                      <div class="product-link--copy">
-//                       <h3>Real Vision <span class="is-highlighted">Think Tank</span></h3>
-//                       <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
-//                       <ul>
-//                          <li>Access to a curation of written investment research</li>
-//                          <li>Sign up for just $365 / year at the end of your trial</li>
-//                       </ul>
+//                  <div class="column is-12">
+//                      <div class="product-link--content">
+//                          <div class="product-link--copy">
+//                          <h3>Real Vision <span class="is-highlighted">Think Tank</span></h3>
+//                          <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
+//                          <ul>
+//                              <li>Access to a curation of written investment research</li>
+//                              <li>Sign up for just $365 / year at the end of your trial</li>
+//                          </ul>
+//                          </div>
 //                      </div>
 //                  </div>
 //                  <div class="product-link__overlay">
@@ -1715,8 +1717,13 @@
             margin-bottom: 0;
         }
 
-        .product-link--copy {
+        .product-link--content {
+            text-align: center;
             padding: $baseline;
+        }
+        .product-link--copy {
+            display: inline-block;
+            text-align: left;
         }
 
         .product-link__overlay {
@@ -1810,8 +1817,8 @@
         }
         .product-link {
             padding-bottom: 0;
-            .product-link--copy {
-                padding: $baseline;
+            .product-link--content {
+                width: 70%;
             }
 
             .product-link__overlay {
@@ -1825,7 +1832,7 @@
                 top: 50%;
                 bottom: auto;
                 transform: translateY(-50%);
-                right: -20px;
+                right: 0;
 
                 span.button {
                     position: absolute;
@@ -1838,7 +1845,7 @@
                     box-shadow: 1px 1px 1px rgba(0,0,0,.4);
                     border-color: transparent;
                     color: #CCC;
-                    padding: .75rem;
+                    padding: 1.5rem 1rem;
                     font-size: 1rem;
                 }
             }

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -1619,79 +1619,52 @@
     }
 }
 
-// Product Links Block
+// Product Links Block - Single Link
 //
 // default - Default Hero
 // :hover - Hover State
 //
 // markup:
 // <div class="product-links-block prospect-component">
-// <div class="columns is-vcentered">
-//    <div class="column is-4-tablet">
+//    <div class="product-links--content">
 //        <div class="product-link product-link--tv {$modifiers}">
 //            <a href="#">
-//                <h3>Watch</h3>
-//                <p>Real Vision</p>
-//                <p><strong>Television</strong></p>
-//                <div class="product-link__bottom-overlay">
-//                    <p class="product-link__bottom-arrow"></p>
+//                <div class="columns is-vertically-centered">
+//                  <div class="column is-6">
+//                      <div class="product-link--copy">
+//                       <h3>Real Vision <span class="is-highlighted">Television</span></h3>
+//                       <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
+//                       <ul>
+//                          <li>Actionable insights from the world's smartest investors</li>
+//                          <li>Subscribe for just $597 / year at the end of your trial</li>
+//                       </ul>
+//                      </div>
+//                  </div>
+//                  <div class="product-link__right-overlay">
+//                      <span class="button" href="/">Subscribe Now</span>
+//                      <p class="product-link__right-arrow"></p>
+//                  </div>
 //                </div>
 //            </a>
 //        </div>
 //    </div>
-//    <div class="column is-4-tablet">
-//        <div class="product-link product-link--publishing {$modifiers}">
-//            <a href="#">
-//                <h3>Read</h3>
-//                <p>Real Vision</p>
-//                <p><strong>Publishing</strong></p>
-//                <div class="product-link__bottom-overlay">
-//                    <p class="product-link__bottom-arrow"></p>
-//                </div>
-//            </a>
-//        </div>
-//    </div>
-//    <div class="column is-4-tablet">
-//        <div class="product-link product-link--podcast {$modifiers}">
-//            <a href="#">
-//                <h3>Listen</h3>
-//                <p>Real Vision</p>
-//                <p><strong>Podcast</strong></p>
-//                <div class="product-link__bottom-overlay">
-//                    <p class="product-link__bottom-arrow"></p>
-//                </div>
-//            </a>
-//        </div>
-//    </div>
-// </div>
 // </div>
 //
 // Styleguide 5.10
 .product-links-block {
-    background-image: url('#{$root}/images/components/product-links-block_bg_mobile.jpg');
-    background-position: center;
-    background-size: cover;
-    background-repeat: no-repeat;
-    padding: $baseline;
-    text-transform: uppercase;
+    padding: 0;
     color: white;
-    text-align: center;
 
     @include tablet {
         background-image: url('#{$root}/images/components/product-links-block_bg.jpg');
     }
 
     .product-link {
-        background: url('#{$root}/images/overlays/white_splatter.png'), $color-dark-gray;
-        background-size: cover;
-        padding-top: 1rem;
-        padding-bottom: 3.5rem;
-        margin: auto;
+        background: url('#{$root}/images/overlays/stripe_clear.png'), $color-dark-gray;
         position: relative;
-        overflow: hidden;
 
-        * {
-            margin: 0;
+        .column {
+            align-self: center;
         }
 
         a {
@@ -1699,33 +1672,69 @@
             text-decoration: none;
         }
 
-        .product-link__bottom-overlay {
-            content: '';
-            width: 100%;
-            height: 100%;
-            max-height: 40px;
-            position: absolute;
-            bottom: -20px;
-            left: 0;
-            transition: bottom 200ms ease-in-out;
-            background: url('#{$root}/images/overlays/stripe_clear.png');
+        ul {
+            margin-bottom: 0;
         }
 
-        .product-link__bottom-arrow {
+        span.is-highlighted {
+            color: $brand;
+        }
+
+        .product-link--copy {
+            padding: $baseline;
+        }
+
+        .product-link__right-overlay {
+            content: '';
+            width: 100%;
+            max-width: 52px;
+            height: 100%;
             position: absolute;
-            bottom: 0;
-            left: 50%;
-            transform: translateX(-50%);
-            height: 20px;
-            border-left: 1.25rem solid transparent;
-            border-right: 1.25rem solid transparent;
-            border-top: 1rem solid $color-dark-gray;
+            top: 50%;
+            transform: translateY(-50%);
+            right: -20px;
+            transition: right 200ms ease-in-out;
+            background: url('#{$root}/images/overlays/stripe_clear.png') $brand;
+            transition: max-width 200ms ease-in-out;
+
+            span.button {
+                position: absolute;
+                opacity: 0;
+                left: 50%;
+                top: 50%;
+                transform: translate(-50%, -50%);
+                transition: opacity 200ms ease-in-out;
+                background: #232323;
+                border-radius: 5px;
+                box-shadow: 1px 1px 1px black;
+            }
+        }
+
+        .product-link__right-arrow {
+            position: absolute;
+            top: 45%;
+            left: 0%;
+            width: 30px;
+            transform: translateY(-50%);
+            border-top: 2rem solid transparent;
+            border-bottom: 2rem solid transparent;
+            border-right: 2rem solid $color-dark-gray;
+            transition: all 200ms ease-in-out;
         }
 
         &:hover {
             cursor: pointer;
-            .product-link__bottom-overlay {
-                bottom: 0px;
+            .product-link__right-overlay {
+                max-width: 50%;
+
+                span.button {
+                    opacity: 1;
+                }
+            }
+            .product-link__right-arrow {
+                right: 9%;
+                border-left: 2rem solid $color-dark-gray;
+                border-right: none;
             }
         }
     }

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -1771,7 +1771,7 @@
 //                  </div>
 //              </div>
 //              <div class="product-cta__overlay">
-//                  <div class="button" href="/"><span>Check it out!</span></div>
+//                  <div class="button"><span>Start my free trial</span></div>
 //                  <p class="product-cta__arrow"></p>
 //              </div>
 //            </div>
@@ -1796,7 +1796,7 @@
 //                      </div>
 //                  </div>
 //                  <div class="product-cta__overlay">
-//                      <div class="button" href="/"><span>Check it out!</span></div>
+//                      <div class="button"><span>Start my free trial</span></div>
 //                      <p class="product-cta__arrow"></p>
 //                  </div>
 //                </div>
@@ -1831,7 +1831,7 @@
     .product-cta {
         background: url('#{$root}/images/overlays/stripe_clear.png'), $color-dark-gray;
         position: relative;
-        padding-bottom: 90px;
+        padding-bottom: 100px;
 
         a {
             color: white;
@@ -1855,7 +1855,7 @@
             width: 100%;
             max-width: none;
             height: 100%;
-            max-height: 90px;
+            max-height: 100px;
             position: absolute;
             top: auto;
             bottom: 0;
@@ -1877,6 +1877,8 @@
                 font-size: 1rem;
                 font-weight: 800;
                 text-align: center;
+                width: 90%;
+                font-size: 1.25rem;
 
                 span {
                     margin: auto;
@@ -1932,6 +1934,16 @@
 
     p {
         font-size: $size-4;
+    }
+
+    @include tablet {
+        .product-cta {
+            .product-cta__overlay {
+                div.button {
+                    width: 65%;
+                }
+            }
+        }
     }
 
     @include desktop {

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -1761,8 +1761,8 @@
 //              <div class="column is-12">
 //                  <div class="product-cta--content">
 //                      <div class="product-cta--copy">
-//                      <h3>Real Vision <span class="is-highlighted">Television</span></h3>
-//                      <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
+//                      <h3>Real Vision <strong>Television</strong></h3>
+//                      <p>Sign up for a <strong>Free Trial</strong> Today</p>
 //                      <ul>
 //                          <li>Actionable insights from the world's smartest investors</li>
 //                          <li>Subscribe for just $597 / year at the end of your trial</li>
@@ -1786,8 +1786,8 @@
 //                  <div class="column is-12">
 //                      <div class="product-cta--content">
 //                          <div class="product-cta--copy">
-//                          <h3>Real Vision <span class="is-highlighted">Think Tank</span></h3>
-//                          <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
+//                          <h3>Real Vision <strong>Think Tank</strong></h3>
+//                          <p>Sign up for a <strong>Free Trial</strong> Today</p>
 //                          <ul>
 //                              <li>Access to a curation of written investment research</li>
 //                              <li>Sign up for just $365 / year at the end of your trial</li>
@@ -1812,7 +1812,7 @@
     overflow: hidden;
     
     .product-cta--think-tank {
-        span.is-highlighted {
+        strong {
             color: $color-poppy;
         }
         .product-cta__overlay {
@@ -1820,7 +1820,7 @@
         }
     }
     .product-cta--tv {
-        span.is-highlighted {
+        strong {
             color: $color-cyan;
         }
         .product-cta__overlay {
@@ -1924,16 +1924,15 @@
     h3 {
         font-size: $size-3;
         line-height: 2.5rem;
+
+        strong {
+            font-weight: 800;
+        }
     }
 
     p {
         font-size: $size-4;
     }
-
-    strong {
-        font-style: normal;
-    }
-
 
     @include desktop {
         .product-cta--think-tank {

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -1630,7 +1630,7 @@
 //        <div class="product-link product-link--tv {$modifiers}">
 //            <a href="#">
 //                <div class="columns is-vertically-centered">
-//                  <div class="column is-6-desktop is-12">
+//                  <div class="column is-8-desktop is-12">
 //                      <div class="product-link--copy">
 //                       <h3>Real Vision <span class="is-highlighted">Television</span></h3>
 //                       <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
@@ -1641,7 +1641,7 @@
 //                      </div>
 //                  </div>
 //                  <div class="product-link__overlay">
-//                      <span class="button" href="/">Subscribe Today</span>
+//                      <span class="button" href="/">Check It Out!</span>
 //                      <p class="product-link__arrow"></p>
 //                  </div>
 //                </div>
@@ -1654,7 +1654,7 @@
 //        <div class="product-link product-link--think-tank {$modifiers}">
 //            <a href="#">
 //                <div class="columns is-vertically-centered">
-//                  <div class="column is-6-desktop is-12">
+//                  <div class="column is-8-desktop is-12">
 //                      <div class="product-link--copy">
 //                       <h3>Real Vision <span class="is-highlighted">Think Tank</span></h3>
 //                       <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
@@ -1665,7 +1665,7 @@
 //                      </div>
 //                  </div>
 //                  <div class="product-link__overlay">
-//                      <span class="button" href="/">Subscribe Today</span>
+//                      <span class="button" href="/">Check It Out!</span>
 //                      <p class="product-link__arrow"></p>
 //                  </div>
 //                </div>
@@ -1676,12 +1676,16 @@
 //
 // Styleguide 5.10
 .product-links-block {
+    padding: 0;
+    color: white;
+    overflow: hidden;
+    
     .product-link--think-tank {
         span.is-highlighted {
             color: $color-poppy;
         }
         .product-link__overlay {
-            background: url('#{$root}/images/overlays/stripe_clear.png') $color-poppy;
+            background: url('#{$root}/images/overlays/stripe_clear.png') rgba(248,147,31,.8);;
         }
     }
     .product-link--tv {
@@ -1689,16 +1693,14 @@
             color: $color-cyan;
         }
         .product-link__overlay {
-            background: url('#{$root}/images/overlays/stripe_clear.png') $color-cyan;
+            background: url('#{$root}/images/overlays/stripe_clear.png') rgba(49,254,232,.8);
         }
     }
-    padding: 0;
-    color: white;
 
     .product-link {
         background: url('#{$root}/images/overlays/stripe_clear.png'), $color-dark-gray;
         position: relative;
-        padding-bottom: 130px;
+        padding-bottom: 90px;
 
         .column {
             align-self: center;
@@ -1722,7 +1724,7 @@
             width: 100%;
             max-width: none;
             height: 100%;
-            max-height: 130px;
+            max-height: 90px;
             position: absolute;
             top: auto;
             bottom: 0;
@@ -1732,13 +1734,14 @@
             span.button {
                 position: absolute;
                 left: 50%;
-                top: 50%;
+                top: 55%;
                 transform: translate(-50%, -50%);
                 transition: all 200ms ease-in-out;
                 background: #232323;
                 border-radius: 5px;
                 box-shadow: 1px 1px 1px rgba(0,0,0,.4);
-                color: #CCC;
+                color: white;
+                border: 2px solid rgba(255,255,255,.9);
                 padding: .75rem;
                 font-size: 1rem;
             }
@@ -1752,7 +1755,7 @@
             transform: translateX(-50%);
             border-left: 2rem solid transparent;
             border-right: 2rem solid transparent;
-            border-top: 1.5rem solid $color-dark-gray;
+            border-top: 1rem solid $color-dark-gray;
         }
 
         &:hover {
@@ -1761,6 +1764,17 @@
                 span.button {
                     color: white;
                     border: 2px solid rgba(255,255,255,.9);
+                }
+            }
+            &.product-link--tv {
+                .product-link__overlay {
+                    background-color: rgba(49,254,232,1);
+                }
+            }
+
+            &.product-link--think-tank {
+                .product-link__overlay {
+                    background-color: rgba(248,147,31,1);
                 }
             }
         }
@@ -1791,9 +1805,10 @@
             }
 
             .product-link__overlay {
+                transition: all 200ms ease-in-out;
                 content: '';
                 width: 100%;
-                max-width: 50%;
+                max-width: 30%;
                 height: 100%;
                 max-height: none;
                 position: absolute;
@@ -1811,9 +1826,10 @@
                     background: #232323;
                     border-radius: 5px;
                     box-shadow: 1px 1px 1px rgba(0,0,0,.4);
+                    border-color: transparent;
                     color: #CCC;
-                    padding: 1.25rem;
-                    font-size: 1.25rem;
+                    padding: .75rem;
+                    font-size: 1rem;
                 }
             }
 
@@ -1826,16 +1842,6 @@
                 border-top: 2rem solid transparent;
                 border-bottom: 2rem solid transparent;
                 border-left: 2rem solid $color-dark-gray;
-            }
-
-            &:hover {
-                cursor: pointer;
-                .product-link__overlay {
-                    span.button {
-                        color: white;
-                        border: 2px solid rgba(255,255,255,.9);
-                    }
-                }
             }
         }
     }

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -1685,7 +1685,7 @@
             color: $color-poppy;
         }
         .product-link__overlay {
-            background: url('#{$root}/images/overlays/stripe_clear.png') rgba(248,147,31,.8);;
+            background: url('#{$root}/images/overlays/stripe_clear.png') rgba(248,147,31,1);;
         }
     }
     .product-link--tv {
@@ -1693,7 +1693,7 @@
             color: $color-cyan;
         }
         .product-link__overlay {
-            background: url('#{$root}/images/overlays/stripe_clear.png') rgba(49,254,232,.8);
+            background: url('#{$root}/images/overlays/stripe_clear.png') rgba(49,254,232,1);
         }
     }
 
@@ -1798,6 +1798,16 @@
     }
 
     @include desktop {
+        .product-link--think-tank {
+            .product-link__overlay {
+                background: url('#{$root}/images/overlays/stripe_clear.png') rgba(248,147,31,.8);
+            }
+        }
+        .product-link--tv {
+            .product-link__overlay {
+                background: url('#{$root}/images/overlays/stripe_clear.png') rgba(49,254,232,.8);
+            }
+        }
         .product-link {
             padding-bottom: 0;
             .product-link--copy {
@@ -1805,7 +1815,7 @@
             }
 
             .product-link__overlay {
-                transition: all 200ms ease-in-out;
+                transition: background 200ms ease-in-out;
                 content: '';
                 width: 100%;
                 max-width: 30%;

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -1792,7 +1792,7 @@
     }
 
     h3 {
-        font-size: $size-1;
+        font-size: $size-3;
         line-height: 2.5rem;
     }
 
@@ -1860,6 +1860,9 @@
                 border-bottom: 2rem solid transparent;
                 border-left: 2rem solid $color-dark-gray;
             }
+        }
+        h3 {
+            font-size: $size-1;
         }
     }
 }

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -1630,7 +1630,7 @@
 //        <div class="product-link product-link--tv {$modifiers}">
 //            <a href="#">
 //                <div class="columns is-vertically-centered">
-//                  <div class="column is-6">
+//                  <div class="column is-6-desktop is-12">
 //                      <div class="product-link--copy">
 //                       <h3>Real Vision <span class="is-highlighted">Television</span></h3>
 //                       <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
@@ -1640,9 +1640,33 @@
 //                       </ul>
 //                      </div>
 //                  </div>
-//                  <div class="product-link__right-overlay">
-//                      <span class="button" href="/">Subscribe Now</span>
-//                      <p class="product-link__right-arrow"></p>
+//                  <div class="product-link__overlay">
+//                      <span class="button" href="/">Subscribe Today</span>
+//                      <p class="product-link__arrow"></p>
+//                  </div>
+//                </div>
+//            </a>
+//        </div>
+//    </div>
+// </div>
+// <div class="product-links-block prospect-component">
+//    <div class="product-links--content">
+//        <div class="product-link product-link--think-tank {$modifiers}">
+//            <a href="#">
+//                <div class="columns is-vertically-centered">
+//                  <div class="column is-6-desktop is-12">
+//                      <div class="product-link--copy">
+//                       <h3>Real Vision <span class="is-highlighted">Think Tank</span></h3>
+//                       <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
+//                       <ul>
+//                          <li>Access to a curation of written investment research</li>
+//                          <li>Sign up for just $365 / year at the end of your trial</li>
+//                       </ul>
+//                      </div>
+//                  </div>
+//                  <div class="product-link__overlay">
+//                      <span class="button" href="/">Subscribe Today</span>
+//                      <p class="product-link__arrow"></p>
 //                  </div>
 //                </div>
 //            </a>
@@ -1652,16 +1676,29 @@
 //
 // Styleguide 5.10
 .product-links-block {
+    .product-link--think-tank {
+        span.is-highlighted {
+            color: $color-poppy;
+        }
+        .product-link__overlay {
+            background: url('#{$root}/images/overlays/stripe_clear.png') $color-poppy;
+        }
+    }
+    .product-link--tv {
+        span.is-highlighted {
+            color: $color-cyan;
+        }
+        .product-link__overlay {
+            background: url('#{$root}/images/overlays/stripe_clear.png') $color-cyan;
+        }
+    }
     padding: 0;
     color: white;
-
-    @include tablet {
-        background-image: url('#{$root}/images/components/product-links-block_bg.jpg');
-    }
 
     .product-link {
         background: url('#{$root}/images/overlays/stripe_clear.png'), $color-dark-gray;
         position: relative;
+        padding-bottom: 130px;
 
         .column {
             align-self: center;
@@ -1676,65 +1713,55 @@
             margin-bottom: 0;
         }
 
-        span.is-highlighted {
-            color: $brand;
-        }
-
         .product-link--copy {
             padding: $baseline;
         }
 
-        .product-link__right-overlay {
+        .product-link__overlay {
             content: '';
             width: 100%;
-            max-width: 52px;
+            max-width: none;
             height: 100%;
+            max-height: 130px;
             position: absolute;
-            top: 50%;
-            transform: translateY(-50%);
-            right: -20px;
-            transition: right 200ms ease-in-out;
-            background: url('#{$root}/images/overlays/stripe_clear.png') $brand;
-            transition: max-width 200ms ease-in-out;
+            top: auto;
+            bottom: 0;
+            transform: translateX(50%);
+            right: 50%;
 
             span.button {
                 position: absolute;
-                opacity: 0;
                 left: 50%;
                 top: 50%;
                 transform: translate(-50%, -50%);
-                transition: opacity 200ms ease-in-out;
+                transition: all 200ms ease-in-out;
                 background: #232323;
                 border-radius: 5px;
-                box-shadow: 1px 1px 1px black;
+                box-shadow: 1px 1px 1px rgba(0,0,0,.4);
+                color: #CCC;
+                padding: .75rem;
+                font-size: 1rem;
             }
         }
 
-        .product-link__right-arrow {
+        .product-link__arrow {
             position: absolute;
-            top: 45%;
-            left: 0%;
+            top: -12px;
+            left: 50%;
             width: 30px;
-            transform: translateY(-50%);
-            border-top: 2rem solid transparent;
-            border-bottom: 2rem solid transparent;
-            border-right: 2rem solid $color-dark-gray;
-            transition: all 200ms ease-in-out;
+            transform: translateX(-50%);
+            border-left: 2rem solid transparent;
+            border-right: 2rem solid transparent;
+            border-top: 1.5rem solid $color-dark-gray;
         }
 
         &:hover {
             cursor: pointer;
-            .product-link__right-overlay {
-                max-width: 50%;
-
+            .product-link__overlay {
                 span.button {
-                    opacity: 1;
+                    color: white;
+                    border: 2px solid rgba(255,255,255,.9);
                 }
-            }
-            .product-link__right-arrow {
-                right: 9%;
-                border-left: 2rem solid $color-dark-gray;
-                border-right: none;
             }
         }
     }
@@ -1754,6 +1781,63 @@
 
     strong {
         font-style: normal;
+    }
+
+    @include desktop {
+        .product-link {
+            padding-bottom: 0;
+            .product-link--copy {
+                padding: $baseline;
+            }
+
+            .product-link__overlay {
+                content: '';
+                width: 100%;
+                max-width: 50%;
+                height: 100%;
+                max-height: none;
+                position: absolute;
+                top: 50%;
+                bottom: auto;
+                transform: translateY(-50%);
+                right: -20px;
+
+                span.button {
+                    position: absolute;
+                    left: 50%;
+                    top: 50%;
+                    transform: translate(-50%, -50%);
+                    transition: all 200ms ease-in-out;
+                    background: #232323;
+                    border-radius: 5px;
+                    box-shadow: 1px 1px 1px rgba(0,0,0,.4);
+                    color: #CCC;
+                    padding: 1.25rem;
+                    font-size: 1.25rem;
+                }
+            }
+
+            .product-link__arrow {
+                position: absolute;
+                top: 45%;
+                left: 0%;
+                width: 30px;
+                transform: translateY(-50%);
+                border-top: 2rem solid transparent;
+                border-bottom: 2rem solid transparent;
+                border-left: 2rem solid $color-dark-gray;
+            }
+
+            &:hover {
+                cursor: pointer;
+                .product-link__overlay {
+                    span.button {
+                        color: white;
+                        border: 2px solid rgba(255,255,255,.9);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -1619,19 +1619,148 @@
     }
 }
 
-// Product Links Block - Single Link
+// Product Links Block
 //
 // default - Default Hero
 // :hover - Hover State
 //
 // markup:
 // <div class="product-links-block prospect-component">
-//    <div class="product-link product-link--tv {$modifiers}">
+// <div class="columns is-vcentered">
+//    <div class="column is-4-tablet">
+//        <div class="product-link product-link--tv {$modifiers}">
+//            <a href="#">
+//                <h3>Watch</h3>
+//                <p>Real Vision</p>
+//                <p><strong>Television</strong></p>
+//                <div class="product-link__bottom-overlay">
+//                    <p class="product-link__bottom-arrow"></p>
+//                </div>
+//            </a>
+//        </div>
+//    </div>
+//    <div class="column is-4-tablet">
+//        <div class="product-link product-link--publishing {$modifiers}">
+//            <a href="#">
+//                <h3>Read</h3>
+//                <p>Real Vision</p>
+//                <p><strong>Publishing</strong></p>
+//                <div class="product-link__bottom-overlay">
+//                    <p class="product-link__bottom-arrow"></p>
+//                </div>
+//            </a>
+//        </div>
+//    </div>
+//    <div class="column is-4-tablet">
+//        <div class="product-link product-link--podcast {$modifiers}">
+//            <a href="#">
+//                <h3>Listen</h3>
+//                <p>Real Vision</p>
+//                <p><strong>Podcast</strong></p>
+//                <div class="product-link__bottom-overlay">
+//                    <p class="product-link__bottom-arrow"></p>
+//                </div>
+//            </a>
+//        </div>
+//    </div>
+// </div>
+// </div>
+//
+// Styleguide 5.10
+.product-links-block {
+    background-image: url('#{$root}/images/components/product-links-block_bg_mobile.jpg');
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
+    padding: $baseline;
+    text-transform: uppercase;
+    color: white;
+    text-align: center;
+
+    @include tablet {
+        background-image: url('#{$root}/images/components/product-links-block_bg.jpg');
+    }
+
+    .product-link {
+        background: url('#{$root}/images/overlays/white_splatter.png'), $color-dark-gray;
+        background-size: cover;
+        padding-top: 1rem;
+        padding-bottom: 3.5rem;
+        margin: auto;
+        position: relative;
+        overflow: hidden;
+
+        * {
+            margin: 0;
+        }
+
+        a {
+            color: white;
+            text-decoration: none;
+        }
+
+        .product-link__bottom-overlay {
+            content: '';
+            width: 100%;
+            height: 100%;
+            max-height: 40px;
+            position: absolute;
+            bottom: -20px;
+            left: 0;
+            transition: bottom 200ms ease-in-out;
+            background: url('#{$root}/images/overlays/stripe_clear.png');
+        }
+
+        .product-link__bottom-arrow {
+            position: absolute;
+            bottom: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            height: 20px;
+            border-left: 1.25rem solid transparent;
+            border-right: 1.25rem solid transparent;
+            border-top: 1rem solid $color-dark-gray;
+        }
+
+        &:hover {
+            cursor: pointer;
+            .product-link__bottom-overlay {
+                bottom: 0px;
+            }
+        }
+    }
+
+    h3, p {
+        font-weight: 800;
+    }
+
+    h3 {
+        font-size: $size-1;
+        line-height: 2.5rem;
+    }
+
+    p {
+        font-size: $size-4;
+    }
+
+    strong {
+        font-style: normal;
+    }
+}
+
+// Single Product CTA
+//
+// default - Default Hero
+// :hover - Hover State
+//
+// markup:
+// <div class="single-product-cta prospect-component">
+//    <div class="product-cta product-cta--tv {$modifiers}">
 //        <a href="#">
 //            <div class="columns is-vertically-centered">
 //              <div class="column is-12">
-//                  <div class="product-link--content">
-//                      <div class="product-link--copy">
+//                  <div class="product-cta--content">
+//                      <div class="product-cta--copy">
 //                      <h3>Real Vision <span class="is-highlighted">Television</span></h3>
 //                      <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
 //                      <ul>
@@ -1641,22 +1770,22 @@
 //                      </div>
 //                  </div>
 //              </div>
-//              <div class="product-link__overlay">
+//              <div class="product-cta__overlay">
 //                  <div class="button" href="/"><span>Check it out!</span></div>
-//                  <p class="product-link__arrow"></p>
+//                  <p class="product-cta__arrow"></p>
 //              </div>
 //            </div>
 //        </a>
 //    </div>
 // </div>
-// <div class="product-links-block prospect-component">
-//    <div class="product-links--content">
-//        <div class="product-link product-link--think-tank {$modifiers}">
+// <div class="single-product-cta prospect-component">
+//    <div class="product-ctas--content">
+//        <div class="product-cta product-cta--think-tank {$modifiers}">
 //            <a href="#">
 //                <div class="columns is-vertically-centered">
 //                  <div class="column is-12">
-//                      <div class="product-link--content">
-//                          <div class="product-link--copy">
+//                      <div class="product-cta--content">
+//                          <div class="product-cta--copy">
 //                          <h3>Real Vision <span class="is-highlighted">Think Tank</span></h3>
 //                          <p>Sign up for a <span class="is-highlighted">Free Trial</span> Today</p>
 //                          <ul>
@@ -1666,9 +1795,9 @@
 //                          </div>
 //                      </div>
 //                  </div>
-//                  <div class="product-link__overlay">
+//                  <div class="product-cta__overlay">
 //                      <div class="button" href="/"><span>Check it out!</span></div>
-//                      <p class="product-link__arrow"></p>
+//                      <p class="product-cta__arrow"></p>
 //                  </div>
 //                </div>
 //            </a>
@@ -1676,30 +1805,30 @@
 //    </div>
 // </div>
 //
-// Styleguide 5.10
-.product-links-block {
+// Styleguide 5.11
+.single-product-cta {
     padding: 0;
     color: white;
     overflow: hidden;
     
-    .product-link--think-tank {
+    .product-cta--think-tank {
         span.is-highlighted {
             color: $color-poppy;
         }
-        .product-link__overlay {
+        .product-cta__overlay {
             background: url('#{$root}/images/overlays/stripe_clear.png') rgba(248,147,31,1);;
         }
     }
-    .product-link--tv {
+    .product-cta--tv {
         span.is-highlighted {
             color: $color-cyan;
         }
-        .product-link__overlay {
+        .product-cta__overlay {
             background: url('#{$root}/images/overlays/stripe_clear.png') rgba(49,254,232,1);
         }
     }
 
-    .product-link {
+    .product-cta {
         background: url('#{$root}/images/overlays/stripe_clear.png'), $color-dark-gray;
         position: relative;
         padding-bottom: 90px;
@@ -1713,16 +1842,16 @@
             margin-bottom: 0;
         }
 
-        .product-link--content {
+        .product-cta--content {
             text-align: center;
             padding: $baseline;
         }
-        .product-link--copy {
+        .product-cta--copy {
             display: inline-block;
             text-align: left;
         }
 
-        .product-link__overlay {
+        .product-cta__overlay {
             width: 100%;
             max-width: none;
             height: 100%;
@@ -1755,7 +1884,7 @@
             }
         }
 
-        .product-link__arrow {
+        .product-cta__arrow {
             position: absolute;
             top: -13px;
             left: 50%;
@@ -1768,20 +1897,20 @@
 
         &:hover {
             cursor: pointer;
-            .product-link__overlay {
+            .product-cta__overlay {
                 div.button {
                     color: white;
                     border: 2px solid rgba(255,255,255,.9);
                 }
             }
-            &.product-link--tv {
-                .product-link__overlay {
+            &.product-cta--tv {
+                .product-cta__overlay {
                     background-color: rgba(49,254,232,1);
                 }
             }
 
-            &.product-link--think-tank {
-                .product-link__overlay {
+            &.product-cta--think-tank {
+                .product-cta__overlay {
                     background-color: rgba(248,147,31,1);
                 }
             }
@@ -1807,23 +1936,23 @@
 
 
     @include desktop {
-        .product-link--think-tank {
-            .product-link__overlay {
+        .product-cta--think-tank {
+            .product-cta__overlay {
                 background: url('#{$root}/images/overlays/stripe_clear.png') rgba(248,147,31,.8);
             }
         }
-        .product-link--tv {
-            .product-link__overlay {
+        .product-cta--tv {
+            .product-cta__overlay {
                 background: url('#{$root}/images/overlays/stripe_clear.png') rgba(49,254,232,.8);
             }
         }
-        .product-link {
+        .product-cta {
             padding-bottom: 0;
-            .product-link--content {
+            .product-cta--content {
                 width: 70%;
             }
 
-            .product-link__overlay {
+            .product-cta__overlay {
                 transition: background 200ms ease-in-out;
                 max-width: 30%;
                 max-height: none;
@@ -1840,7 +1969,7 @@
                 }
             }
 
-            .product-link__arrow {
+            .product-cta__arrow {
                 top: 45%;
                 left: 0%;
                 transform: translateY(-50%);
@@ -1914,7 +2043,7 @@
 //  </div>
 // </div>
 //
-// Styleguide 5.11
+// Styleguide 5.12
 .link-blocks {
     padding: $baseline;
     text-transform: uppercase;
@@ -2048,7 +2177,7 @@
 //      </div>
 // </a>
 //
-// Styleguide 5.12
+// Styleguide 5.13
 .play-block {
     display: block;
     background-image: url('#{$root}/images/components/product-play-block-bg.jpg');
@@ -2153,7 +2282,7 @@
 //      </div>
 // </div>
 //
-// Styleguide 5.13
+// Styleguide 5.14
 .product-listing--item {
     padding: $baseline;
 
@@ -2248,7 +2377,7 @@
 //      <p class="email-capture--error">Oops! It looks like something went wrong. Please try again.</p>
 // </div>
 //
-// Styleguide 5.14
+// Styleguide 5.15
 .email-capture--simple {
     padding: $baseline;
 
@@ -2364,7 +2493,7 @@
 //      </div>
 // </div>
 //
-// Styleguide 5.15
+// Styleguide 5.16
 .email-capture--dropdown {
     padding: $baseline;
 
@@ -2528,7 +2657,7 @@
 //    </div>
 // </div>
 //
-// Styleguide 5.16
+// Styleguide 5.17
 .product-price-block {
     padding: $baseline;
     position: relative;
@@ -2790,7 +2919,7 @@
 //      </div>
 // </div>
 //
-// Styleguide 5.17
+// Styleguide 5.18
 .image-row {
     padding: $baseline;
     background: none;
@@ -2928,7 +3057,7 @@
 //      </div>
 // </div>
 //
-// Styleguide 5.18
+// Styleguide 5.19
 .pullout-container {
     padding: 0;
 
@@ -3006,7 +3135,7 @@
 //      </ol>
 // </div>
 //
-// Styleguide 5.19
+// Styleguide 5.20
 .wysiwyg-block {
     padding: $baseline;
     h2, h3 {
@@ -3143,7 +3272,7 @@
 //          </div>
 // </section>
 //
-// Styleguide 5.20
+// Styleguide 5.21
 .podcast-episode {
     padding: $baseline;
     background: white;
@@ -3376,7 +3505,7 @@
 //      </section>
 // </div>
 //
-// Styleguide 5.21
+// Styleguide 5.22
 .podcast-listing {
     padding: $baseline / 2;
 
@@ -3513,7 +3642,7 @@
 //    </div>
 //  </div>
 //
-// Styleguide 5.22
+// Styleguide 5.23
 .contributor-header.is-black {
     background: #111111;
     color: white;
@@ -3646,7 +3775,7 @@
 //     </div>
 // </div>
 // 
-// Styleguide 5.23
+// Styleguide 5.24
 .countdown-banner {
     background-color: $color-poppy;
     background-image: url(#{$root}/images/components/countdown_banner_background.png);

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -1642,7 +1642,7 @@
 //                  </div>
 //              </div>
 //              <div class="product-link__overlay">
-//                  <span class="button" href="/">Check It Out!</span>
+//                  <div class="button" href="/"><span>Check it out!</span></div>
 //                  <p class="product-link__arrow"></p>
 //              </div>
 //            </div>
@@ -1667,7 +1667,7 @@
 //                      </div>
 //                  </div>
 //                  <div class="product-link__overlay">
-//                      <span class="button" href="/">Check It Out!</span>
+//                      <div class="button" href="/"><span>Check it out!</span></div>
 //                      <p class="product-link__arrow"></p>
 //                  </div>
 //                </div>
@@ -1704,10 +1704,6 @@
         position: relative;
         padding-bottom: 90px;
 
-        .column {
-            align-self: center;
-        }
-
         a {
             color: white;
             text-decoration: none;
@@ -1727,7 +1723,6 @@
         }
 
         .product-link__overlay {
-            content: '';
             width: 100%;
             max-width: none;
             height: 100%;
@@ -1738,25 +1733,31 @@
             transform: translateX(50%);
             right: 50%;
 
-            span.button {
+            div.button {
                 position: absolute;
                 left: 50%;
                 top: 55%;
                 transform: translate(-50%, -50%);
                 transition: all 200ms ease-in-out;
-                background: #232323;
+                background: $color-dark-gray;
                 border-radius: 5px;
                 box-shadow: 1px 1px 1px rgba(0,0,0,.4);
                 color: white;
                 border: 2px solid rgba(255,255,255,.9);
                 padding: .75rem;
                 font-size: 1rem;
+                font-weight: 800;
+                text-align: center;
+
+                span {
+                    margin: auto;
+                }
             }
         }
 
         .product-link__arrow {
             position: absolute;
-            top: -12px;
+            top: -13px;
             left: 50%;
             width: 30px;
             transform: translateX(-50%);
@@ -1768,7 +1769,7 @@
         &:hover {
             cursor: pointer;
             .product-link__overlay {
-                span.button {
+                div.button {
                     color: white;
                     border: 2px solid rgba(255,255,255,.9);
                 }
@@ -1804,6 +1805,7 @@
         font-style: normal;
     }
 
+
     @include desktop {
         .product-link--think-tank {
             .product-link__overlay {
@@ -1823,38 +1825,24 @@
 
             .product-link__overlay {
                 transition: background 200ms ease-in-out;
-                content: '';
-                width: 100%;
                 max-width: 30%;
-                height: 100%;
                 max-height: none;
-                position: absolute;
                 top: 50%;
                 bottom: auto;
                 transform: translateY(-50%);
                 right: 0;
 
-                span.button {
-                    position: absolute;
-                    left: 50%;
-                    top: 50%;
-                    transform: translate(-50%, -50%);
-                    transition: all 200ms ease-in-out;
-                    background: #232323;
-                    border-radius: 5px;
-                    box-shadow: 1px 1px 1px rgba(0,0,0,.4);
+                div.button {
                     border-color: transparent;
+                    top: 50%;
                     color: #CCC;
                     padding: 1.5rem 1rem;
-                    font-size: 1rem;
                 }
             }
 
             .product-link__arrow {
-                position: absolute;
                 top: 45%;
                 left: 0%;
-                width: 30px;
                 transform: translateY(-50%);
                 border-top: 2rem solid transparent;
                 border-bottom: 2rem solid transparent;

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -1940,7 +1940,7 @@
         .product-cta {
             .product-cta__overlay {
                 div.button {
-                    width: 65%;
+                    width: 75%;
                 }
             }
         }


### PR DESCRIPTION
Adds a new component to the styleguide meant to replace the current Product Links Blocks used incorrectly throughout the site. This design has been approved by Nisha and Lauren and signed off by Ryan. The development of the Wordpress component will start soon. This is a pre-emptive PR.
**DO NOT MERGE** until Wordpress component PR is in.

**Desktop View**
![screen shot 2018-03-15 at 3 54 13 pm](https://user-images.githubusercontent.com/5661484/37490669-4ce3cc46-2869-11e8-96c6-a275e2fc4bca.png)

**Mobile View**
![screen shot 2018-03-15 at 3 54 30 pm](https://user-images.githubusercontent.com/5661484/37490693-5a6d3122-2869-11e8-93cc-1b9e072faeef.png)

