### PR TITLE
Fixes bottom banner width bug

### DIFF
--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -3948,5 +3948,14 @@
         position: fixed;
         bottom: 0;
         z-index: 10;
+
+        @include from($desktop) {
+            max-width: 960px;
+            width: 960px;
+        }
+        @media screen and (min-width: 1260px) {
+            max-width: 1152px;
+            width: 1152px;
+        }
     }
 }


### PR DESCRIPTION
This PR includes a standard media query to set the max-width of the component at the highest screen width. This was done because the `$widescreen` variable is seemingly set to 1200px, while the page container itself responds to 1260px.