### PR TITLE
RV-3206: Comment replies visual bug in Safari

### DIFF
--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -703,7 +703,7 @@
             position: absolute;
             top: 0;
             left: 0;
-            background: linear-gradient(to top, transparent, white);
+            background: linear-gradient(to top, rgba(255,255,255,0), white);
         }
     }
 


### PR DESCRIPTION
It seems that Safari renders the `transparent` value differently than the other browsers? Using a transparent rgba instead seems to resolve the issue.